### PR TITLE
[v4v] Fix module refcnt.

### DIFF
--- a/v4v/v4v.c
+++ b/v4v/v4v.c
@@ -3048,7 +3048,15 @@ v4v_accept (struct v4v_private *p, struct v4v_addr *peer, int nonblock)
       printk (KERN_ERR "v4v_accept priv %p => %p\n", p, a);
 #endif
 
-	  v4v_kfree(r);
+      v4v_kfree(r);
+
+      /*
+       * A new fd with a struct file having its struct file_operations in this
+       * module is to be returned. The refcnt need to reflect that, so bump it.
+       * Since that fd will eventualy be closed, the .release() callback will
+       * decrement the refcnt.
+       */
+      try_module_get(THIS_MODULE);
 
       return fd;
 


### PR DESCRIPTION
V4VIOCACCEPT allocates a new struct file without bumping the refcnt for
the module. The struct file is assigned v4v_fops_stream and a fd is
returned to userspace. When this fd is closed, the release() callback in
v4v_fops_stream file operations is called and the kernel will decrement
the module refcnt.
To maintain refcnt coherency, it has to be incremented when the struct
file is created, so when the fds are closed by userland, the refcnt does
not get decremented twice where is was only incremented once. Anyway,
returning a new fd should increase the refcnt.
