### PR TITLE
v4v: use get_unused_fd() for kernel versions <3.7

### DIFF
--- a/v4v/v4v.c
+++ b/v4v/v4v.c
@@ -2856,7 +2856,11 @@ allocate_fd_with_private (void *private)
   struct inode *ind;
 #endif
 
+#if (LINUX_VERSION_CODE < KERNEL_VERSION(3,7,0))
+  fd = get_unused_fd();
+#else
   fd = get_unused_fd_flags(O_CLOEXEC);
+#endif
   if (fd < 0)
     return fd;
 


### PR DESCRIPTION
The replacement, get_unused_fd_flags() is a macro
which uses non-exported alloc_fd(), up until 3.7.

This adds a version check to decide which form to use.

Signed-off-by: Chris Patterson pattersonc@ainfosec.com
