### PR TITLE
OXT-791: HYPERCALL_DECLS changed

### DIFF
--- a/v4v/include/xen/hypercall6.h
+++ b/v4v/include/xen/hypercall6.h
@@ -29,6 +29,16 @@
 #endif
 
 #undef __HYPERCALL_DECLS
+#if LINUX_VERSION_CODE < KERNEL_VERSION(4,6,0)
+#define __HYPERCALL_DECLS						    \
+	register unsigned long __res  asm(__HYPERCALL_RETREG);		    \
+	register unsigned long __arg1 asm(__HYPERCALL_ARG1REG) = __arg1;    \
+	register unsigned long __arg2 asm(__HYPERCALL_ARG2REG) = __arg2;    \
+	register unsigned long __arg3 asm(__HYPERCALL_ARG3REG) = __arg3;    \
+	register unsigned long __arg4 asm(__HYPERCALL_ARG4REG) = __arg4;    \
+	register unsigned long __arg5 asm(__HYPERCALL_ARG5REG) = __arg5;    \
+	register unsigned long __arg6 asm(__HYPERCALL_ARG6REG) = __arg6;
+#else
 #define __HYPERCALL_DECLS						\
 	register unsigned long __res  asm(__HYPERCALL_RETREG);		\
 	register unsigned long __arg1 asm(__HYPERCALL_ARG1REG) = __arg1; \
@@ -36,10 +46,11 @@
 	register unsigned long __arg3 asm(__HYPERCALL_ARG3REG) = __arg3; \
 	register unsigned long __arg4 asm(__HYPERCALL_ARG4REG) = __arg4; \
 	register unsigned long __arg5 asm(__HYPERCALL_ARG5REG) = __arg5; \
-	register unsigned long __arg6 asm(__HYPERCALL_ARG6REG) = __arg6;
+	register unsigned long __arg6 asm(__HYPERCALL_ARG6REG) = __arg6; \
+	register void *__sp asm(_ASM_SP);
+#endif
 
 #undef __HYPERCALL_CLOBBER5
-
 #define __HYPERCALL_CLOBBER6	"memory"
 #define __HYPERCALL_CLOBBER5	__HYPERCALL_CLOBBER6, __HYPERCALL_ARG6REG
 


### PR DESCRIPTION
We should really not touch HYPERCALL_DECLS and remove hypercall6 altogether. This is TBD already with coming V4V work (and also covers repository duplication).

OXT-791
