### PR TITLE
OXT-1285: v4v: Pass fomit-frame-pointer when targeting x86.

### DIFF
--- a/v4v/Makefile
+++ b/v4v/Makefile
@@ -20,6 +20,9 @@ V4V_VERSION=1.0
 obj-m += v4v.o 
 KVERSION := $(shell uname -r)
 
+# 6-args hypercall will use ebp for the 6th argument on x86.
+ccflags-$(CONFIG_X86_32) += -fomit-frame-pointer
+
 all:
 	make -C /lib/modules/${KVERSION}/build M=$(PWD) modules -I$(PWD) EXTRA_CFLAGS="-g -I$(PWD)/include -I$(PWD)"
 


### PR DESCRIPTION
Since GCC 6.4, fomit-frame-pointer does not seem to be guarantied when
targeting x86. Since v4v uses ebp for 6-arguments hypercalls to Xen on
x86, add -fomit-frame-pointer for that target.o

This used to be default on OE/Jethro with GCC 4.3.

OXT-1285