### PR TITLE
STABLE-8: OXT-1304: V4V Improvements

### DIFF
--- a/v4v/linux/v4v_dev.h
+++ b/v4v/linux/v4v_dev.h
@@ -27,11 +27,28 @@ typedef enum
   V4V_PTYPE_STREAM,
 } v4v_ptype;
 
+/* The pointers make this depend on compilation. */
 struct v4v_dev {
 	void *buf;
 	size_t len;
 	int flags;
 	v4v_addr_t *addr;
+};
+
+/* A 64bit version of v4v_dev */
+struct v4v_dev_64 {
+	uint64_t buf;
+	size_t len;
+	int flags;
+	uint64_t addr;
+};
+
+/* A 32bit version of v4v_dev used for compat ioctls */
+struct v4v_dev_32 {
+	uint32_t buf;
+	uint32_t len;
+	int32_t flags;
+	uint32_t addr;
 };
 
 struct v4v_viptables_rule_pos {
@@ -51,6 +68,9 @@ struct v4v_viptables_rule_pos {
 #define V4VIOCACCEPT		_IOW (V4V_TYPE,  8, v4v_addr_t) 
 #define V4VIOCSEND		_IOW (V4V_TYPE,  9, struct v4v_dev)
 #define V4VIOCRECV		_IOW (V4V_TYPE, 10, struct v4v_dev)
+/* V4VIOCSEND32==V4VIOCSEND for 32bit kernels, but not for compat 64bit */
+#define V4VIOCSEND32		_IOW (V4V_TYPE,  9, struct v4v_dev_32)
+#define V4VIOCRECV32		_IOW (V4V_TYPE, 10, struct v4v_dev_32)
 #define V4VIOCVIPTABLESADD	_IOW (V4V_TYPE, 11, struct v4v_viptables_rule_pos)
 #define V4VIOCVIPTABLESDEL	_IOW (V4V_TYPE, 12, struct v4v_viptables_rule_pos)
 #define V4VIOCVIPTABLESLIST	_IOW (V4V_TYPE, 13, uint32_t) /*unused args */

--- a/v4v/v4v.c
+++ b/v4v/v4v.c
@@ -2924,6 +2924,7 @@ allocate_fd_with_private (void *private)
 
 
   f->private_data = private;
+  f->f_flags = O_RDWR;
 
   fd_install (fd, f);
 
@@ -3286,6 +3287,8 @@ v4v_open_dgram (struct inode *inode, struct file *f)
 #endif
 
   f->private_data = p;
+  f->f_flags = O_RDWR;
+
   return 0;
 }
 
@@ -3318,6 +3321,8 @@ v4v_open_stream (struct inode *inode, struct file *f)
 #endif
 
   f->private_data = p;
+  f->f_flags = O_RDWR;
+
   return 0;
 }
 

--- a/v4v/v4v.c
+++ b/v4v/v4v.c
@@ -49,6 +49,7 @@
 #endif /* XC_DKMS */
 
 #include <linux/version.h>
+#include <linux/compat.h>
 #include <linux/mm.h>
 #include <linux/init.h>
 #include <linux/module.h>
@@ -3675,13 +3676,81 @@ v4v_ioctl (struct file *f, unsigned int cmd, unsigned long arg)
       }
       break;
     default:
-      printk (KERN_ERR "unkown ioctl: V4VIOCACCEPT=%x\n", V4VIOCACCEPT);
+      printk (KERN_ERR "unknown ioctl: cmd=%x V4VIOCACCEPT=%x\n", cmd,
+              V4VIOCACCEPT);
       DEBUG_BANANA;
     }
   DEBUG_APPLE;
   return rc;
 }
 
+#ifdef CONFIG_COMPAT
+static long
+v4v_compat_ioctl (struct file *f, unsigned int cmd, unsigned long arg)
+{
+    int nonblock = f->f_flags & O_NONBLOCK;
+    struct v4v_private *p = f->private_data;
+    int rc;
+
+    switch (cmd) {
+    case V4VIOCSEND32:
+      {
+        struct v4v_dev a;
+        struct v4v_dev_32 a32;
+        v4v_addr_t addr, *paddr = NULL;
+
+        if (copy_from_user (&a32, (void __user *)arg, sizeof(a32)))
+          return -EFAULT;
+
+        a.buf = compat_ptr(a32.buf);
+        a.len = a32.len;
+        a.flags = a32.flags;
+        a.addr = compat_ptr(a32.addr);
+
+        if (a.addr) {
+          if (copy_from_user (&addr, (void __user *)a.addr, sizeof(v4v_addr_t)))
+            return -EFAULT;
+          paddr = &addr;
+          DEBUG_APPLE;
+        }
+
+        rc = v4v_sendto (p, a.buf, a.len, a.flags, paddr, nonblock);
+      }
+      break;
+    case V4VIOCRECV32:
+      DEBUG_APPLE;
+      {
+        struct v4v_dev_32 a32;
+        struct v4v_dev a;
+        v4v_addr_t addr;
+
+        if (copy_from_user (&a32, (void __user *)arg, sizeof(a32)))
+          return -EFAULT;
+
+        a.buf = compat_ptr(a32.buf);
+        a.len = a32.len;
+        a.flags = a32.flags;
+        a.addr = compat_ptr(a32.addr);
+
+        if (a.addr) {
+            if (copy_from_user (&addr, a.addr, sizeof(v4v_addr_t)))
+              return -EFAULT;
+            rc = v4v_recvfrom (p, a.buf, a.len, a.flags, &addr, nonblock);
+            if (rc < 0)
+              return rc;
+            if (copy_to_user (a.addr, &addr, sizeof(v4v_addr_t)))
+              return -EFAULT;
+        } else
+            rc = v4v_recvfrom (p, a.buf, a.len, a.flags, NULL, nonblock);
+      }
+      break;
+    default:
+      rc = v4v_ioctl(f, cmd, (unsigned long)compat_ptr(arg));
+    }
+
+    return rc;
+}
+#endif
 
 static unsigned int
 v4v_poll (struct file *f, poll_table * pt)
@@ -3754,6 +3823,9 @@ static const struct file_operations v4v_fops_stream = {
   .write = v4v_write,
   .read = v4v_read,
   .unlocked_ioctl = v4v_ioctl,
+#ifdef CONFIG_COMPAT
+  .compat_ioctl = v4v_compat_ioctl,
+#endif
   .open = v4v_open_stream,
   .release = v4v_release,
   .poll = v4v_poll,
@@ -3765,6 +3837,9 @@ static const struct file_operations v4v_fops_dgram = {
   .write = v4v_write,
   .read = v4v_read,
   .unlocked_ioctl = v4v_ioctl,
+#ifdef CONFIG_COMPAT
+  .compat_ioctl = v4v_compat_ioctl,
+#endif
   .open = v4v_open_dgram,
   .release = v4v_release,
   .poll = v4v_poll,


### PR DESCRIPTION
This is the Stable-8 version of https://github.com/OpenXT/v4v/pull/32

These are a two improvements to the v4v driver. The first marks v4v file descriptors as read-write. Otherwise they appear as read-only which causes problems for applications that check. The second adds a compat ioctl to support 32bit userspace on a 64bit kernel. Without this, 32bit ioctls are not recognized by the driver.

OXT-1304