### PR TITLE
OXT-1304: v4v: Disable SMAP when invoking hypercall

### DIFF
--- a/v4v/v4v.h
+++ b/v4v/v4v.h
@@ -58,9 +58,15 @@
 #define __HYPERVISOR_v4v_op               39
 static inline int __must_check
 HYPERVISOR_v4v_op(int cmd, void *arg1, void *arg2, void *arg3,
-			uint32_t arg4, uint32_t arg5)                         
-{                                                             
-	return _hypercall6(int, v4v_op, cmd, arg1, arg2, arg3, arg4, arg5);
+			uint32_t arg4, uint32_t arg5)
+{
+	int ret;
+
+	stac();
+	ret = _hypercall6(int, v4v_op, cmd, arg1, arg2, arg3, arg4, arg5);
+	clac();
+
+	return ret;
 }
 #endif
 


### PR DESCRIPTION
v4v hypercalls trip SMAP since the hypervisor sees the processor in ring
0 from the hypercall, but the data buffer is in userspace.  Avoid
tripping SMAP by using stac/clac as if it were a userspace access.

This is the fix preferred by the Xen maintainers.

Signed-off-by: Jason Andryuk <jandryuk@gmail.com>